### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
     <img src="https://img.shields.io/github/license/gimjin/message-mcp" alt="MIT License">
   </a>
 </div>
+<a href="https://glama.ai/mcp/servers/@gimjin/message-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gimjin/message-mcp/badge" alt="message-mcp MCP server" />
+</a>
 
 ## 🤔 Are you still using AI in this "micromanaging" way?
 


### PR DESCRIPTION
This PR adds a badge for the [message-mcp](https://glama.ai/mcp/servers/@gimjin/message-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gimjin/message-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gimjin/message-mcp/badge" alt="message-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.